### PR TITLE
Add -r regex to setup.py to fix broken installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ def parse_requirements(file_name):
             pass
         else:
             requirements.append(line)
-    print requirements
     return requirements
 
 


### PR DESCRIPTION
Only -f was being tested, but -r was used in requirements.txt and that broke "setup.py install"
