### PR TITLE
Showing right representation of Pluct resources

### DIFF
--- a/pluct/resource.py
+++ b/pluct/resource.py
@@ -162,6 +162,9 @@ class ObjectResource(datastructures.IterableUserDict, Resource, dict):
     def __getitem__(self, item):
         return Resource.__getitem__(self, item)
 
+    def __repr__(self):
+        return "<Pluct ObjectResource %s>" % self.data
+
 
 class ArrayResource(datastructures.UserList, Resource, list):
 
@@ -182,3 +185,6 @@ class ArrayResource(datastructures.UserList, Resource, list):
 
     def __getitem__(self, item):
         return Resource.__getitem__(self, item)
+
+    def __repr__(self):
+        return "<Pluct ArrayResource %s>" % self.data

--- a/pluct/tests/test_resource.py
+++ b/pluct/tests/test_resource.py
@@ -79,7 +79,8 @@ class ResourceTestCase(BaseTestCase):
             self.result.not_found
 
     def test_str(self):
-        self.assertEqual(str(self.data), str(self.result))
+        expected = "<Pluct ObjectResource %s>" % self.data
+        self.assertEqual(expected, str(self.result))
 
     def test_data(self):
         self.assertEqual(self.data, self.result.data)
@@ -299,6 +300,8 @@ class ResourceFromDataTestCase(BaseTestCase):
         self.assertIsInstance(resource, ArrayResource)
         self.assertEqual(resource.url, '/')
         self.assertEqual(resource.data, data)
+        expected = "<Pluct ArrayResource %s>" % resource.data
+        self.assertEqual(expected, str(resource))
 
     def test_should_create_object_resource_from_dict(self):
         data = {}


### PR DESCRIPTION
No more errors processing pluct instead of dict or list.
Example:
```
resource = {'hi': 'man'} # bad repr
json.dumps(resource) # = {} instead of {'hi': 'man'}
```